### PR TITLE
Fix Slurm settings in Hydra

### DIFF
--- a/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 sanity_check_paths = {
-    'files': ['bin/update-cesm-machines', 'scripts/case.job'],
+    'files': ['bin/update-cesm-machines', 'scripts/case.pbs', 'scripts/case.slurm'],
     'dirs': ['machines', 'irods'],
 }
 

--- a/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
@@ -37,7 +37,7 @@ sanity_check_paths = {
 usage = """Environment to build and run CESM v2 simulations
  - Download a release of CESM v2: `git clone -b release-cesm2.2.0 https://github.com/ESCOMP/cesm.git cesm-2.2.0`
  - Download external programs for CESM: `cd cesm-2.2.0; ./manage_externals/checkout_externals`
- - Copy config files for Breniac: `cp $EBROOTCESMMINDEPS/machines/2.1/config_*.xml cime/config/cesm/machines/`
+ - Update config files: `update-cesm-machines cime/config/cesm/machines/ $EBROOTCESMMINDEPS/machines/`
  - Create case: `cd cime/scripts && ./create_newcase --machine breniac ...`"""
 
 moduleclass = 'geo'

--- a/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'intel', 'version': '2019b'}
 
 # install extra tools to configure CESM
 source_urls = ['https://github.com/vub-hpc/cesm-config/archive/']
-sources = ['v1.5.0.tar.gz']
+sources = ['v1.5.1.tar.gz']
 
 dependencies = [
     ('CMake', '3.15.3'),

--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -45,7 +45,7 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
       <arg flag="-p" name="$JOB_QUEUE"/>
     </submit_args>
     <queues>
-      <queue walltimemin="00:60:00" walltimemax="120:00:00" nodemin="1" nodemax="12" default="true">skylake_mpi</queue>
+      <queue walltimemin="00:15:00" walltimemax="120:00:00" nodemin="1" nodemax="12" default="true">skylake_mpi</queue>
     </queues>
   </batch_system>
 

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -94,7 +94,7 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>impi</MPILIBS>
-    <CIME_OUTPUT_ROOT>$ENV{VSC_SCRATCH}/cime/output</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{VSC_SCRATCH}/cesm/output</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{VSC_SCRATCH}/cesm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$ENV{VSC_SCRATCH}/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
@@ -137,7 +137,7 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>impi</MPILIBS>
-    <CIME_OUTPUT_ROOT>$ENV{VSC_SCRATCH}/cime/output</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{VSC_SCRATCH}/cesm/output</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{VSC_SCRATCH}/cesm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$ENV{VSC_SCRATCH}/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -58,10 +58,9 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     <mpirun mpilib="impi">
       <executable>srun</executable>
       <arguments>
-	    <arg name="label"> --label</arg>
-	    <arg name="num_tasks"> -n {{ total_tasks }}</arg>
-	    <arg name="thread_count"> -c {{ cores_per_task }}</arg>
-	    <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="module">

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -83,6 +83,9 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
         <command name="load">CESM-deps/2-intel-2019b</command>
       </modules>
     </module_system>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
   </machine>
 
   <machine MACH="breniac">

--- a/scripts/case.pbs
+++ b/scripts/case.pbs
@@ -11,8 +11,8 @@ cd $PBS_O_WORKDIR
 
 # CESM case setup
 echo
-./preview_run
 ./case.setup --reset
+./preview_run
 
 # CESM case build
 echo

--- a/scripts/case.slurm
+++ b/scripts/case.slurm
@@ -9,8 +9,8 @@ module load CESM-deps/2-intel-2019b
 
 # CESM case setup
 echo
-./preview_run
 ./case.setup --reset
+./preview_run
 
 # CESM case build
 echo

--- a/scripts/case.slurm
+++ b/scripts/case.slurm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module purge
-module load CESM-deps/2-foss-2019a
+module load CESM-deps/2-intel-2019b
 
 # Runtime settings
 ./xmlchange NTASKS=${SLURM_NTASKS}


### PR DESCRIPTION
Changelog:
* set an unlimited stack size (`RLIMIT_STACK`)
* remove `cpus-per-task` setting and only use MPI tasks
* set CPU binding to sockets
* reduce minimum allowed time for jobs in Hydra to 15 min
* use same file structure in Hydra and Breniac
* fix sanity checks in the easyconfig file
* fix module loaded in the job script for slurm