### PR TITLE
update for Hortense and CESM-deps/2-foss-2021b

### DIFF
--- a/easyconfigs/CESM-deps/CESM-deps-2-foss-2021b.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-foss-2021b.eb
@@ -1,0 +1,50 @@
+easyblock = 'Bundle'
+
+name = 'CESM-deps'
+version = '2'
+
+homepage = 'https://www.cesm.ucar.edu/models/cesm2/'
+description = """CESM is a fully-coupled, community, global climate model that
+provides state-of-the-art computer simulations of the Earth's past, present,
+and future climate states."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('CMake', '3.22.1'),
+    ('Python', '3.9.6'),
+    ('lxml', '4.6.3'),
+    ('Perl', '5.34.0'),
+    ('XML-LibXML', '2.0207'),
+    ('ESMF', '8.2.0'),
+    ('netCDF', '4.8.1'),
+    ('netCDF-Fortran', '4.5.3'),
+    ('netCDF-C++4', '4.3.1'),
+    ('PnetCDF', '1.12.3'),
+    ('Subversion', '1.14.1'),
+    ('git', '2.33.1', '-nodocs'),
+    ('git-lfs', '3.2.0', '', True),
+]
+
+components = [
+    # install extra configuration tools for CESM
+    ('cesm-config', '1.6.0', {
+        'easyblock': 'Tarball',
+        'source_urls': ['https://github.com/vub-hpc/%(name)s/archive'],
+        'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}],
+        'start_dir': '%(name)s-%(version)s',
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/update-cesm-machines', 'scripts/case.pbs', 'scripts/case.slurm'],
+    'dirs': ['machines', 'irods'],
+}
+
+usage = """Environment to build and run CESM v2 simulations
+ 1. Download a release of CESM v2: `git clone -b release-cesm2.2.0 https://github.com/ESCOMP/cesm.git cesm-2.2.0`
+ 2. Add external programs for CESM: `cd cesm-2.2.0; ./manage_externals/checkout_externals`
+ 3. Update config files: `update-cesm-machines cime/config/cesm/machines/ $EBROOTCESMMINDEPS/machines/`
+ 4. Create case: `cd cime/scripts && ./create_newcase --machine ...`"""
+
+moduleclass = 'geo'

--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -49,6 +49,20 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     </queues>
   </batch_system>
 
+  <batch_system MACH="hortense" type="slurm">
+    <batch_submit>sbatch</batch_submit>
+    <jobid_pattern>job (\d+)</jobid_pattern>
+    <submit_args>
+      <arg flag="-t" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-p" name="$JOB_QUEUE"/>
+      <arg flag="-A" name="$PROJECT"/>
+    </submit_args>
+    <queues>
+      <queue walltimemin="00:15:00" walltimemax="72:00:00" nodemax="256" default="true">cpu_rome</queue>
+      <queue walltimemin="00:15:00" walltimemax="72:00:00" nodemax="42">cpu_rome_512</queue>
+    </queues>
+  </batch_system>
+
   <batch_system MACH="breniac" type="pbs">
     <directives>
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>

--- a/machines/config_compilers.xml
+++ b/machines/config_compilers.xml
@@ -37,6 +37,32 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
 
 <config_compilers>
 
+  <compiler MACH="hydra">
+    <ESMF_LIBDIR>$ENV{EBROOTESMF}/lib</ESMF_LIBDIR>
+    <NETCDF_PATH>$ENV{EBROOTNETCDF}</NETCDF_PATH>
+    <NETCDF_C_PATH>$ENV{EBROOTNETCDFMINCPLUSPLUS4}</NETCDF_C_PATH>
+    <NETCDF_FORTRAN_PATH>$ENV{EBROOTNETCDFMINFORTRAN}</NETCDF_FORTRAN_PATH>
+    <PNETCDF_PATH>$ENV{EBROOTPNETCDF}</PNETCDF_PATH>
+    <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  </compiler>
+  <compiler MACH="hydra" COMPILER="gnu">
+    <MPICC> mpicc  </MPICC>
+    <MPICXX> mpicxx </MPICXX>
+    <MPIFC> mpif90 </MPIFC>
+    <SCC> gcc </SCC>
+    <SCXX> g++ </SCXX>
+    <SFC> gfortran </SFC>
+    <CFLAGS>
+      <append DEBUG="FALSE"> -O2 </append>
+    </CFLAGS>
+    <FFLAGS>
+      <append DEBUG="FALSE"> -O2 -fallow-argument-mismatch -fallow-invalid-boz </append>
+    </FFLAGS>
+    <SLIBS>
+      <append> -L$ENV{EBROOTSCALAPACK}/lib -lscalapack -L$ENV{EBROOTOPENBLAS}/lib -lopenblas </append>
+      <append> -L$ENV{EBROOTNETCDFMINFORTRAN}/lib -lnetcdff -L$ENV{EBROOTNETCDF}/lib -lnetcdf </append>
+    </SLIBS>
+  </compiler>
   <compiler MACH="hydra" COMPILER="intel">
     <MPICC> mpiicc  </MPICC>
     <MPICXX> mpiicpc </MPICXX>
@@ -51,14 +77,8 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
       <append DEBUG="FALSE"> -xCOMMON-AVX512 -no-fma </append>
     </FFLAGS>
     <SLIBS>
-      <append> -L$ENV{EBROOTNETCDFMINFORTRAN}/lib -lnetcdff -L$ENV{EBROOTNETCDF}/lib64 -lnetcdf </append>
+      <append> -L$ENV{EBROOTNETCDFMINFORTRAN}/lib -lnetcdff -L$ENV{EBROOTNETCDF}/lib -lnetcdf </append>
     </SLIBS>
-    <ESMF_LIBDIR>$ENV{EBROOTESMF}/lib</ESMF_LIBDIR>
-    <NETCDF_PATH>$ENV{EBROOTNETCDF}</NETCDF_PATH>
-    <NETCDF_C_PATH>$ENV{EBROOTNETCDFMINCPLUSPLUS4}</NETCDF_C_PATH>
-    <NETCDF_FORTRAN_PATH>$ENV{EBROOTNETCDFMINFORTRAN}</NETCDF_FORTRAN_PATH>
-    <PNETCDF_PATH>$ENV{EBROOTPNETCDF}</PNETCDF_PATH>
-    <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
   </compiler>
 
   <compiler MACH="breniac" COMPILER="intel">

--- a/machines/config_compilers.xml
+++ b/machines/config_compilers.xml
@@ -81,6 +81,33 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     </SLIBS>
   </compiler>
 
+  <compiler MACH="hortense">
+    <ESMF_LIBDIR>$ENV{EBROOTESMF}/lib</ESMF_LIBDIR>
+    <NETCDF_PATH>$ENV{EBROOTNETCDF}</NETCDF_PATH>
+    <NETCDF_C_PATH>$ENV{EBROOTNETCDFMINCPLUSPLUS4}</NETCDF_C_PATH>
+    <NETCDF_FORTRAN_PATH>$ENV{EBROOTNETCDFMINFORTRAN}</NETCDF_FORTRAN_PATH>
+    <PNETCDF_PATH>$ENV{EBROOTPNETCDF}</PNETCDF_PATH>
+    <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  </compiler>
+  <compiler MACH="hortense" COMPILER="gnu">
+    <MPICC> mpicc  </MPICC>
+    <MPICXX> mpicxx </MPICXX>
+    <MPIFC> mpif90 </MPIFC>
+    <SCC> gcc </SCC>
+    <SCXX> g++ </SCXX>
+    <SFC> gfortran </SFC>
+    <CFLAGS>
+      <append DEBUG="FALSE"> -O2 </append>
+    </CFLAGS>
+    <FFLAGS>
+      <append DEBUG="FALSE"> -O2 -fallow-argument-mismatch -fallow-invalid-boz </append>
+    </FFLAGS>
+    <SLIBS>
+      <append> -L$ENV{EBROOTSCALAPACK}/lib -lscalapack -L$ENV{EBROOTOPENBLAS}/lib -lopenblas </append>
+      <append> -L$ENV{EBROOTNETCDFMINFORTRAN}/lib -lnetcdff -L$ENV{EBROOTNETCDF}/lib -lnetcdf </append>
+    </SLIBS>
+  </compiler>
+
   <compiler MACH="breniac" COMPILER="intel">
     <MPICC> mpiicc  </MPICC>
     <MPICXX> mpiicpc </MPICXX>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -102,8 +102,8 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     <GMAKE_J>16</GMAKE_J>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>HPC-Ugent</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mympirun</executable>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -74,10 +74,6 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
       <cmd_path lang="csh">module -q</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">XML-LibXML/2.0201-GCCcore-8.3.0</command>
-        <command name="load">Python/2.7.16-GCCcore-8.3.0</command>
-        <command name="load">CMake/3.15.3-GCCcore-8.3.0</command>
-        <command name="load">git/2.23.0-GCCcore-8.3.0-nodocs</command>
       </modules>
       <modules compiler="intel">
         <command name="load">CESM-deps/2-intel-2019b</command>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -38,11 +38,12 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
 <config_machines>
 
   <machine MACH="hydra">
-    <DESC> Hydra - heterogeneous cluster at VUB, batch system is PBS</DESC>
+    <DESC> Hydra - heterogeneous cluster at VUB, batch system is Slurm</DESC>
     <NODENAME_REGEX>(node3.*\.hydra\.(os|brussel\.vsc)|login.*\.cerberus\.os)</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel</COMPILERS>
-    <MPILIBS>impi</MPILIBS>
+    <COMPILERS>intel,gnu</COMPILERS>
+    <MPILIBS compiler="intel">impi</MPILIBS>
+    <MPILIBS compiler="gnu">openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{VSC_SCRATCH}/cesm/output</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{VSC_SCRATCH}/cesm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$ENV{VSC_SCRATCH}/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -55,11 +56,10 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     <MAX_TASKS_PER_NODE>40</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>40</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="impi">
+    <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
         <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
-        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
         <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
@@ -77,6 +77,9 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
       </modules>
       <modules compiler="intel">
         <command name="load">CESM-deps/2-intel-2019b</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">CESM-deps/2-foss-2021b</command>
       </modules>
     </module_system>
     <resource_limits>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -87,6 +87,49 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     </resource_limits>
   </machine>
 
+  <machine MACH="hortense">
+    <DESC> Hortense - Tier-1 cluster at UGent, batch system is Slurm</DESC>
+    <NODENAME_REGEX>(node|login)\d+\.dodrio\.os</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS compiler="gnu">openmpi</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{VSC_SCRATCH}/cesm/output</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>$ENV{VSC_SCRATCH}/cesm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$ENV{VSC_SCRATCH}/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$ENV{VSC_SCRATCH}/cesm/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>$ENV{VSC_SCRATCH}/cesm/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>16</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>HPC-Ugent</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>mympirun</executable>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/usr/share/lmod/lmod/init/env_modules_python.py</init_path>
+      <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
+      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
+      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl -q</cmd_path>
+      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python -q</cmd_path>
+      <cmd_path lang="sh">module -q</cmd_path>
+      <cmd_path lang="csh">module -q</cmd_path>
+      <modules>
+        <command name="purge"/>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">CESM-deps/2-foss-2021b</command>
+        <command name="load">vsc-mympirun</command>
+      </modules>
+    </module_system>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
+  </machine>
+
   <machine MACH="breniac">
     <DESC> BrENIAC - Tier-1 cluster of VSC, batch system is PBS</DESC>
     <NODENAME_REGEX>(r0[0-9]i[0-9]+n[12]|login1)</NODENAME_REGEX>

--- a/scripts/case.setupbuild.slurm
+++ b/scripts/case.setupbuild.slurm
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=CESM-case-setupbuild
+#SBATCH --output="%x-%j.out"
+#SBATCH --time=4:00:00
+#SBATCH --nodes 1
+#SBATCH --ntasks 16
+
+module load CESM-deps/2-foss-2021b
+
+# CESM case setup
+echo
+./case.setup --reset
+./preview_run
+
+# CESM case build
+echo
+./case.build


### PR DESCRIPTION
Changelog:

* add easyconfig for CESM-deps/2-foss-2021b
* update configuration for Hydra to use CESM-deps/2-foss-2021b with `--compiler=gnu` while the older CESM-deps/2-intel-2019b can continue to be used with `--compiler=intel`
* add configuration settings for Hortense
* add job script `case.setupbuild.slurm` to setup and build cases
* update README