### PR TITLE
remove custom job id pattern for Hydra

### DIFF
--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -39,7 +39,6 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
 
   <batch_system MACH="hydra" type="slurm">
     <batch_submit>sbatch</batch_submit>
-    <jobid_pattern>job (\d+)</jobid_pattern>
     <submit_args>
       <arg flag="-t" name="$JOB_WALLCLOCK_TIME"/>
       <arg flag="-p" name="$JOB_QUEUE"/>


### PR DESCRIPTION
The default pattern for Slum works out of the box in Hydra